### PR TITLE
Fix UI overlap between field and captured cards

### DIFF
--- a/koikoi/ui_manager.py
+++ b/koikoi/ui_manager.py
@@ -33,7 +33,7 @@ class UIManager:
     def draw_field(self):
         """Draws the cards on the field."""
         for i, card in enumerate(self.game_controller.field.cards):
-            card.rect.topleft = (100 + (i % 8) * (CARD_WIDTH * 0.7), 350 + (i // 8) * (CARD_HEIGHT + 5))
+            card.rect.topleft = (100 + (i % 8) * (CARD_WIDTH * 0.7), 250 + (i // 8) * (CARD_HEIGHT + 5))
             card.draw(self.screen)
 
     def draw_player_hand(self):
@@ -69,7 +69,7 @@ class UIManager:
 
     def draw_captured_piles(self):
         """Draws the cards captured by each player."""
-        self._draw_card_pile(self.screen, self.game_controller.player.captured_cards, (50, SCREEN_HEIGHT - 450), "Player's Captured")
+        self._draw_card_pile(self.screen, self.game_controller.player.captured_cards, (50, 520), "Player's Captured")
         self._draw_card_pile(self.screen, self.game_controller.cpu.captured_cards, (50, 50), "CPU's Captured")
 
     def draw_deck(self):


### PR DESCRIPTION
The field cards and the player's captured cards were overlapping on the screen. This was due to the y-coordinates used for drawing these elements being too close to each other.

This commit adjusts the y-coordinates in `koikoi/ui_manager.py` to provide more space between the field and the player's captured card pile, resolving the visual overlap.

Specifically:
- The field drawing now starts at y=250 instead of y=350.
- The player's captured pile is now drawn at a fixed y=520 instead of a calculated position that was causing the issue.